### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -529,7 +529,11 @@ async def download_report(filename: str):
     sanitized_filename = os.path.basename(filename)
     if sanitized_filename != filename:
         raise HTTPException(status_code=400, detail="Invalid filename")
-    file_path = os.path.join(OUTPUT_DIR, sanitized_filename)
+    file_path = os.path.normpath(os.path.join(OUTPUT_DIR, sanitized_filename))
+    output_dir_abs = os.path.abspath(OUTPUT_DIR)
+    # Ensure file_path stays strictly within the output directory
+    if not file_path.startswith(output_dir_abs + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid path")
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="File not found")
     return FileResponse(


### PR DESCRIPTION
Potential fix for [https://github.com/Edric2412/Automated-Report-Generator/security/code-scanning/1](https://github.com/Edric2412/Automated-Report-Generator/security/code-scanning/1)

To fully address this vulnerability, we need to ensure that the requested file is strictly inside the intended output directory, even after any attempted tricks by the user. The best general-purpose fix is to use `os.path.normpath` and then verify that the resulting path is strictly inside `OUTPUT_DIR` using a path prefix check after normalization. Specifically, after joining `OUTPUT_DIR` and `sanitized_filename`, normalize the resulting path and then check that the normalized path starts with the absolute path of OUTPUT_DIR plus a path separator. If it does not, the request should be rejected.

Edits are required in the `/download_report/{filename}` route handler, specifically on lines 532 and following: use `os.path.normpath` to normalize the joined path, then re-validate that the full path starts with the absolute `OUTPUT_DIR`. Additionally, to ensure robust checking, use `os.path.abspath` on OUTPUT_DIR. These changes only require editing backend/main.py in the relevant region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
