### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -529,11 +529,16 @@ async def download_report(filename: str):
     sanitized_filename = os.path.basename(filename)
     if sanitized_filename != filename:
         raise HTTPException(status_code=400, detail="Invalid filename")
-    file_path = os.path.join(OUTPUT_DIR, sanitized_filename)
-    if not os.path.exists(file_path):
+    # Normalize and check path containment
+    file_path = os.path.normpath(os.path.join(OUTPUT_DIR, sanitized_filename))
+    abs_output_dir = os.path.abspath(OUTPUT_DIR)
+    abs_file_path = os.path.abspath(file_path)
+    if not abs_file_path.startswith(abs_output_dir + os.sep):
+        raise HTTPException(status_code=400, detail="Attempt to access file outside output directory")
+    if not os.path.exists(abs_file_path):
         raise HTTPException(status_code=404, detail="File not found")
     return FileResponse(
-        file_path,
+        abs_file_path,
         media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         filename=sanitized_filename
     )


### PR DESCRIPTION
Potential fix for [https://github.com/Edric2412/Automated-Report-Generator/security/code-scanning/2](https://github.com/Edric2412/Automated-Report-Generator/security/code-scanning/2)

The best way to fix this is to normalize the joined file path with `os.path.normpath` and ensure that it is contained within the intended safe directory (`OUTPUT_DIR`). This check will prevent attackers from accessing files outside `OUTPUT_DIR` via path traversal (like `../../otherdir/file.docx`) or other filesystem tricks. The edit is required in the `/download_report/{filename}` route handler in backend/main.py, specifically around lines 527–539.

The fix requires you to:
- After joining `OUTPUT_DIR` and `sanitized_filename`, normalize the result (using `os.path.normpath`).
- Check that the normalized path starts with the absolute (resolved) `OUTPUT_DIR` directory (using `.startswith` after converting both to absolute paths).
- If the check fails, raise an HTTP 400 error.
- Use the safe, normalized path for the subsequent `os.path.exists` and `FileResponse`.

No new imports are needed, since `os` is already imported. You only need to edit the block handling the file download route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
